### PR TITLE
Validate tags before allowing CDK to deploy changes

### DIFF
--- a/config/eks/dev_eks_config.ts
+++ b/config/eks/dev_eks_config.ts
@@ -7,7 +7,7 @@ import request from 'sync-request-curl'; //npm install sync-request-curl (cdk re
 //EasyEKS Admins: edit this file with config to apply to all dev cluster's in your org.
 
 export function apply_config(config: Easy_EKS_Config_Data, stack: cdk.Stack){ //config: is of type Easy_EKS_Config_Data
-    config.addTag("purpose", "example");
+    config.addTag("Environment", "Dev");
 }//end apply_config()
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/config/eks/dev_eks_config.ts
+++ b/config/eks/dev_eks_config.ts
@@ -7,7 +7,7 @@ import request from 'sync-request-curl'; //npm install sync-request-curl (cdk re
 //EasyEKS Admins: edit this file with config to apply to all dev cluster's in your org.
 
 export function apply_config(config: Easy_EKS_Config_Data, stack: cdk.Stack){ //config: is of type Easy_EKS_Config_Data
-    config.addTag("Environment", "Dev");
+    config.addTag("purpose", "example");
 }//end apply_config()
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/config/eks/global_baseline_eks_config.ts
+++ b/config/eks/global_baseline_eks_config.ts
@@ -9,13 +9,16 @@ import request from 'sync-request-curl'; //npm install sync-request-curl (cdk re
 
 //export function apply_config(config: Easy_EKS_Config_Data, stack: cdk.Stack, cluster: eks.Cluster){ //config: is of type Easy_EKS_Config_Data
 export function apply_config(config: Easy_EKS_Config_Data, stack: cdk.Stack){ //config: is of type Easy_EKS_Config_Data    
-    config.addTag("AWS Tag Allowed Characters", "letters numbers + - = . _ : / @ WebSiteLinks");
-    config.addTag("AWS Tag Forbidden Characters", "Hashtag Comma SingleQuote DoubleQuote Parenthesis QuestionMark Asterisk Ampersand https://docs.aws.amazon.com/codeguru/latest/bugbust-ug/limits-tags.html");
     config.addTag("IaC Tooling used for Provisioning and Management of this EKS Cluster", "cdk: a CLI tool that stands for AWS Cloud Development Kit.");
     config.addTag("Upstream Methodology Docs", "https://github.com/doitintl/easyeks");
-    //^-- NOTE: hashtag(#)   comma(,)   singlequote(')   doublequote(\")   parenthesis()   and more are not valid tag values
-    //    https://docs.aws.amazon.com/codeguru/latest/bugbust-ug/limits-tags.html
-    /*Note it's possible when updating tags, that you could see 
+    //^-- NOTE: AWS tag restrictions vary by service, but generally only letters, numbers, spaces, and the following characters are allowed: + - = . _ : / @
+    //    Tags are validated by the validateTag() function in lib/Utilities.ts before deployment
+    //    More details:
+    //      - https://docs.aws.amazon.com/eks/latest/userguide/eks-using-tags.html#tag-restrictions
+    //      - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
+
+    /*
+    Note it's possible when updating tags, that you could see 
     An error like AWS::EKS::Nodegroup "Update is not supported for the following properties"
     If that happens temporarily edit the following line in Easy_EKS.ts
     this.cluster.addNodegroupCapacity(`default_MNG`, default_MNG);

--- a/config/eks/global_baseline_eks_config.ts
+++ b/config/eks/global_baseline_eks_config.ts
@@ -16,24 +16,7 @@ export function apply_config(config: Easy_EKS_Config_Data, stack: cdk.Stack){ //
     //    More details:
     //      - https://docs.aws.amazon.com/eks/latest/userguide/eks-using-tags.html#tag-restrictions
     //      - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
-
-    /*
-    Note it's possible when updating tags, that you could see 
-    An error like AWS::EKS::Nodegroup "Update is not supported for the following properties"
-    If that happens temporarily edit the following line in Easy_EKS.ts
-    this.cluster.addNodegroupCapacity(`default_MNG`, default_MNG);
-    to
-    this.cluster.addNodegroupCapacity(`default_MNG-1`, default_MNG);
-    redeploy and it'll go through
-    then rename it back
-    Note: 
-    After setting default_MNG-1, you may see ...is in UPDATE_ROLLBACK_FAILED state and can not be updated
-    If so, go to CloudFormation -> stack -> Stack actions -> continue update rollback for stack - Advanced troubleshooting
-    --> resources to skip - optional (check the box) --> Continue update rollback. 
-    (wait 10 sec, then retry cdk deploy stack)
-    */
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
+    
 }//end apply_config()
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/config/vpc/global_baseline_vpc_config.ts
+++ b/config/vpc/global_baseline_vpc_config.ts
@@ -2,10 +2,11 @@ import { Opinionated_VPC_Config_Data } from '../../lib/Opinionated_VPC_Config_Da
 import * as cdk from 'aws-cdk-lib';
 
 export function apply_config(config: Opinionated_VPC_Config_Data, stack: cdk.Stack){ //config: is of type Opinionated_VPC_Config_Data
-    config.addTag("AWS Tag Allowed Characters", "letters numbers + - = . _ : / @ WebSiteLinks");
-    config.addTag("AWS Tag Forbidden Character", "Hashtag Comma SingleQuote DoubleQuote Parenthesis QuestionMark Asterisk Ampersand https://docs.aws.amazon.com/codeguru/latest/bugbust-ug/limits-tags.html");
     config.addTag("IaC Tooling used for Provisioning and Management of this VPC", "cdk: a CLI tool that stands for AWS Cloud Development Kit.");
     config.addTag("Upstream Methodology Docs", "https://github.com/doitintl/easyeks");
-    //^-- NOTE: hashtag(#)   comma(,)   singlequote(')   doublequote(\")   parenthesis()   and more are not valid tag values
-    //    https://docs.aws.amazon.com/codeguru/latest/bugbust-ug/limits-tags.html
+    //^-- NOTE: AWS tag restrictions vary by service, but generally only letters, numbers, spaces, and the following characters are allowed: + - = . _ : / @
+    //    Tags are validated by the validateTag() function in lib/Utilities.ts before deployment
+    //    More details:
+    //      - https://docs.aws.amazon.com/eks/latest/userguide/eks-using-tags.html#tag-restrictions
+    //      - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
 }//end apply_config

--- a/lib/Easy_EKS_Config_Data.ts
+++ b/lib/Easy_EKS_Config_Data.ts
@@ -4,6 +4,7 @@ import * as eks from 'aws-cdk-lib/aws-eks';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { execSync } from 'child_process';
+import {InvalidInputError, validateTag} from './Utilities';
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 type EKSAddOnInput = Optional<eks.CfnAddonProps, 'clusterName'>; //makes clusterName Optional parameter
@@ -83,9 +84,15 @@ export class Easy_EKS_Config_Data { //This object just holds config data.
     }
     setKubernetesVersion(version: KubernetesVersion){ this.kubernetesVersion = version; }
     setKubectlLayer(version: cdk.aws_lambda.ILayerVersion ){ this.kubectlLayer = version; }
-    addTag(key: string, value: string){ 
-        if(this.tags === undefined){ this.tags = { [key] : value } }
-        else{ this.tags = { ...this.tags, [key] : value }}
+    addTag(key: string, value: string){
+        try {
+            validateTag(key, value)
+            if(this.tags === undefined){ this.tags = { [key] : value } }
+            else{ this.tags = { ...this.tags, [key] : value }}
+        } catch (error: any) {
+            console.error("Error:", error.message)
+            // throw "Error: Invalid tag key or value" // Using throw here to stop the checks; otherwise an error will print out for every place this tag would be applied
+        }
     }
     setBaselineMNGSize(num_baseline_nodes: number){
         this.baselineNodesNumber = num_baseline_nodes;

--- a/lib/Easy_EKS_Config_Data.ts
+++ b/lib/Easy_EKS_Config_Data.ts
@@ -4,7 +4,7 @@ import * as eks from 'aws-cdk-lib/aws-eks';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { execSync } from 'child_process';
-import {InvalidInputError, validateTag} from './Utilities';
+import { validateTag } from './Utilities';
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 type EKSAddOnInput = Optional<eks.CfnAddonProps, 'clusterName'>; //makes clusterName Optional parameter

--- a/lib/Easy_EKS_Config_Data.ts
+++ b/lib/Easy_EKS_Config_Data.ts
@@ -91,7 +91,7 @@ export class Easy_EKS_Config_Data { //This object just holds config data.
             else{ this.tags = { ...this.tags, [key] : value }}
         } catch (error: any) {
             console.error("Error:", error.message)
-            // throw "Error: Invalid tag key or value" // Using throw here to stop the checks; otherwise an error will print out for every place this tag would be applied
+            throw "Error validating tags. See details above"// Using throw here to stop the checks; otherwise an error will print out for every place this tag would be applied, and the process will continue
         }
     }
     setBaselineMNGSize(num_baseline_nodes: number){

--- a/lib/Opinionated_VPC_Config_Data.ts
+++ b/lib/Opinionated_VPC_Config_Data.ts
@@ -1,6 +1,6 @@
 import { FckNatInstanceProvider, FckNatInstanceProps } from 'cdk-fck-nat' //source: npm install cdk-fck-nat@latest
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
-import {InvalidInputError, validateTag} from './Utilities';
+import { validateTag } from './Utilities';
 
 export class Opinionated_VPC_Config_Data { //This object just holds config data.
     //Typescript(TS) readability notes

--- a/lib/Opinionated_VPC_Config_Data.ts
+++ b/lib/Opinionated_VPC_Config_Data.ts
@@ -1,5 +1,6 @@
 import { FckNatInstanceProvider, FckNatInstanceProps } from 'cdk-fck-nat' //source: npm install cdk-fck-nat@latest
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import {InvalidInputError, validateTag} from './Utilities';
 
 export class Opinionated_VPC_Config_Data { //This object just holds config data.
     //Typescript(TS) readability notes
@@ -30,9 +31,15 @@ export class Opinionated_VPC_Config_Data { //This object just holds config data.
 
 
     //Config Snippet Population Methods
-    addTag(key: string, value: string){ 
-        if(this.tags === undefined){ this.tags = [{key: key, value: value}] }
-        else{ this.tags.push({key: key, value: value}) }
+    addTag(key: string, value: string){
+        try {
+            validateTag(key, value)
+            if(this.tags === undefined){ this.tags = [{key: key, value: value}] }
+            else{ this.tags.push({key: key, value: value}) }
+        } catch (error: any) {
+            console.error("Error:", error.message)
+            // throw "Error: Invalid tag key or value" // Using throw here to stop the checks; otherwise an error will print out for every place this tag would be applied
+        }
     }
     setNatGatewayProviderAsFckNat(props: FckNatInstanceProps){
         this.natGatewayProvider = new FckNatInstanceProvider( props );

--- a/lib/Opinionated_VPC_Config_Data.ts
+++ b/lib/Opinionated_VPC_Config_Data.ts
@@ -38,7 +38,7 @@ export class Opinionated_VPC_Config_Data { //This object just holds config data.
             else{ this.tags.push({key: key, value: value}) }
         } catch (error: any) {
             console.error("Error:", error.message)
-            // throw "Error: Invalid tag key or value" // Using throw here to stop the checks; otherwise an error will print out for every place this tag would be applied
+            throw "Error validating tags. See details above"// Using throw here to stop the checks; otherwise an error will print out for every place this tag would be applied, and the process will continue
         }
     }
     setNatGatewayProviderAsFckNat(props: FckNatInstanceProps){

--- a/lib/Utilities.ts
+++ b/lib/Utilities.ts
@@ -13,6 +13,8 @@ export function validateTag(key: string, value: string){
 
     if (!allowedRegex.test(key)){
         throw new InvalidInputError(`Invalid tag key: "${key}". ${allowedCharsText}`)
+    } else if (key.startsWith("aws:")) {
+        throw new InvalidInputError(`Invalid tag key "${key}". Tag keys cannot start with "aws:".`)
     } else if (!allowedRegex.test(value)){
         throw new InvalidInputError(`Invalid tag value: "${value}". ${allowedCharsText}`)
     } else {

--- a/lib/Utilities.ts
+++ b/lib/Utilities.ts
@@ -12,9 +12,9 @@ export function validateTag(key: string, value: string){
     const allowedRegex = new RegExp(allowedChars, "mu");
 
     if (!allowedRegex.test(key)){
-        throw new InvalidInputError(`Invalid tag key: "${key}"\n${allowedCharsText}`)
+        throw new InvalidInputError(`Invalid tag key: "${key}". ${allowedCharsText}`)
     } else if (!allowedRegex.test(value)){
-        throw new InvalidInputError(`Invalid tag value: "${value}"\n${allowedCharsText}`)
+        throw new InvalidInputError(`Invalid tag value: "${value}". ${allowedCharsText}`)
     } else {
         return true
     }

--- a/lib/Utilities.ts
+++ b/lib/Utilities.ts
@@ -1,0 +1,22 @@
+export class InvalidInputError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "InvalidInputError";
+    }
+}
+
+export function validateTag(key: string, value: string){
+    const allowedChars = "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"; // https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Tag.html; also using cfn-lint as a baseline
+    // The set of allowed characters varies by service, from basically any character to a strict set of English alphanumeric characters and a few symbols
+    const allowedCharsText = "The string can only contain Unicode letters, digits, whitespace, and the characters _.:/=+\-@";
+    const allowedRegex = new RegExp(allowedChars, "mu");
+
+    if (!allowedRegex.test(key)){
+        throw new InvalidInputError(`Invalid tag key: "${key}"\n${allowedCharsText}`)
+    } else if (!allowedRegex.test(value)){
+        throw new InvalidInputError(`Invalid tag value: "${value}"\n${allowedCharsText}`)
+    } else {
+        return true
+    }
+}
+

--- a/lib/Utilities.ts
+++ b/lib/Utilities.ts
@@ -13,7 +13,7 @@ export function validateTag(key: string, value: string){
 
     if (!allowedRegex.test(key)){
         throw new InvalidInputError(`Invalid tag key: "${key}". ${allowedCharsText}`)
-    } else if (key.startsWith("aws:")) {
+    } else if (key.toLowerCase().startsWith("aws:")) {
         throw new InvalidInputError(`Invalid tag key "${key}". Tag keys cannot start with "aws:".`)
     } else if (!allowedRegex.test(value)){
         throw new InvalidInputError(`Invalid tag value: "${value}". ${allowedCharsText}`)

--- a/lib/Utilities.ts
+++ b/lib/Utilities.ts
@@ -1,4 +1,4 @@
-export class InvalidInputError extends Error {
+class InvalidInputError extends Error {
     constructor(message: string) {
         super(message);
         this.name = "InvalidInputError";


### PR DESCRIPTION
Per https://doitintl.atlassian.net/browse/CSI-1648

## Overview

Instead of displaying tags via a public (but obscured) web page, this creates a tag validation function that helps make sure user-added tags follow AWS tagging requirements.

This means users get alerted about this immediate before deployment; previously when CDK/CloudFormation tried to deploy resources with invalid tags, the deployment would still start but would fail to create the tagged resources, which could take a while.

## Solution

Validates tags using the regex `^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$` (unicode characters plus generally allowed special characters). This varies by service, but covers most cases, including EC2/VPC/EKS tag allowances. (https://docs.aws.amazon.com/eks/latest/userguide/eks-using-tags.html)

## Testing

Tested for a new deployment:
![image](https://github.com/user-attachments/assets/b387d6c3-d121-45f4-b908-2ea1938a1eb8)

Tested as a tag update to an existing deployment:
![image](https://github.com/user-attachments/assets/9ab1c319-e571-4c96-bdc5-d97be31a271d)

Tested a mixed-case "AwS:" key prefix:
![image](https://github.com/user-attachments/assets/30cbcd90-9bed-48e0-8e48-c467d00bc741)
