### PR TITLE
Security Improvement's associated with Jira Task CSI-1647

### DIFF
--- a/config/eks/higher_envs_eks_config.ts
+++ b/config/eks/higher_envs_eks_config.ts
@@ -16,7 +16,11 @@ export function apply_config(config: Easy_EKS_Config_Data, stack: cdk.Stack){ //
     config.setBaselineMNGType(eks.CapacityType.ON_DEMAND);
     if(process.env.CDK_DEFAULT_ACCOUNT==="111122223333"){
         config.addClusterAdminARN(`arn:aws:iam::111122223333:user/example`); 
-        /* Note: 
+        /* Note 1:
+           The IAM user/role running cdk deploy dev1-eks, gets added to the list of Cluster Admins by default.
+           This is done for convenience, if you want to change this default, you'll need to edit ./lib/Easy_EKS.ts
+
+           Note 2: 
            config.addClusterAdminARN('...:user/example') should only be used in an if statement,
            Because the identity referenced in ARN must exist or the deployment will fail
            This allows you to create a explicit list of ARNs (representing IAM roles or users)

--- a/config/eks/lower_envs_eks_config.ts
+++ b/config/eks/lower_envs_eks_config.ts
@@ -15,8 +15,12 @@ export function apply_config(config: Easy_EKS_Config_Data, stack: cdk.Stack){ //
     config.setBaselineMNGSize(2);
     config.setBaselineMNGType(eks.CapacityType.SPOT);
     if(process.env.CDK_DEFAULT_ACCOUNT==="111122223333"){
-        config.addClusterAdminARN(`arn:aws:iam::111122223333:user/example`); 
-        /* Note: 
+        config.addClusterAdminARN(`arn:aws:iam::111122223333:user/example`);
+        /* Note 1:
+           The IAM user/role running cdk deploy dev1-eks, gets added to the list of Cluster Admins by default.
+           This is done for convenience, if you want to change this default, you'll need to edit ./lib/Easy_EKS.ts
+
+           Note 2: 
            config.addClusterAdminARN('...:user/example') should only be used in an if statement,
            Because the identity referenced in ARN must exist or the deployment will fail
            This allows you to create a explicit list of ARNs (representing IAM roles or users)

--- a/docs/03_Quickstart/Quickstart.md
+++ b/docs/03_Quickstart/Quickstart.md
@@ -299,10 +299,10 @@ dev1-eks: creating CloudFormation changeset...
 ✨  Deployment time: 1052.74s
 
 Outputs:
-dev1-eks.dev1eksConfigCommand9B300592 = aws eks update-kubeconfig --name dev1-eks --region ca-central-1 --role-arn arn:aws:iam::905418347382:role/dev1-eks-assumableEKSAdminAccessRoleC284FA0F-F22KjKQrjLpO
-dev1-eks.dev1eksGetTokenCommandDE6D6947 = aws eks get-token --cluster-name dev1-eks --region ca-central-1 --role-arn arn:aws:iam::905418347382:role/dev1-eks-assumableEKSAdminAccessRoleC284FA0F-F22KjKQrjLpO
-Stack ARN:
-arn:aws:cloudformation:ca-central-1:905418347382:stack/dev1-eks/60d97430-27d0-11f0-ae18-0e71104456e5
+dev1-eks.iamWhitelistedKubeConfigCmd = aws eks update-kubeconfig --region ca-central-1 --name dev1-eks
+
+Note: This only works for the user/role deploying cdk and IAM Whitelisted Admins.
+      To learn more review ./easyeks/config/eks/lower_envs_eks_config.ts
 
 ✨  Total time: 1069.52s
 ```

--- a/lib/Easy_EKS.ts
+++ b/lib/Easy_EKS.ts
@@ -1,11 +1,3 @@
-// The point of this is to investigate not using eks-blueprints, which has been problematic.
-// * not as maintained as I 1st thought, https://github.com/aws-quickstart/cdk-eks-blueprints/graphs/code-frequency
-// * It's karpenter has been busted for a long time, I suspect this standalone could be more reliable https://github.com/aws-samples/cdk-eks-karpenter
-// * Many operations can only be done against object of type eks.Cluster, blueprints made that hard to get access to
-//   I found edge case limitations where even though I can access it by overriding an internal protected method I can't do things like deploy yaml
-//   due to an order of operations issue, so going to do a major refactor to get rid of EKS Blueprint in favor of L2 construct.
-//   v2 will be based on https://github.com/aws/aws-cdk/tree/main/packages/aws-cdk-lib/aws-eks#aws-iam-mapping
-
 import console = require('console'); //can help debug feedback loop, allows `console.log("hi");` to work, when `cdk list` is run.
 import { Construct, IConstruct } from 'constructs';
 import * as cdk from 'aws-cdk-lib';
@@ -26,6 +18,31 @@ import * as prod_eks_config from '../config/eks/prod_eks_config';
 import * as observability from './Frugal_GPL_Observability_Stack';
 import * as shell from 'shelljs'; //npm install shelljs && npm i --save-dev @types/shelljs
 import request from 'sync-request-curl'; //npm install sync-request-curl (cdk requires sync functions, async not allowed)
+
+
+
+class CDK_Deployer { 
+    // After cdk deploy dev1-eks is run, a kubectl population command will be displayed
+    // Example:
+    // aws eks update-kubeconfig --region ca-central-1 --name dev1-eks
+    //
+    // For good security we lock this down to whitelisted IAM access entries, defined in the Access tab of EKS's web console
+    // For convienence we make an assumption that the IAM identity running cdk deploy dev1-eks, should be auto-added to that list.
+    // A singleton pattern is used to avoid multiple lookups.
+    private static singleton: CDK_Deployer;
+    private static iam_id: string;
+    public static get_IAM_ID(): string{
+        if(!CDK_Deployer.singleton){
+            CDK_Deployer.singleton = new CDK_Deployer();
+            const cmd = `aws sts get-caller-identity | jq .Arn | tr -d '"|\n|\r'`; //translate delete (remove) double quote & new lines
+            const cmd_results = shell.exec(cmd, {silent:true});
+            if(cmd_results.code===0){
+                this.iam_id = cmd_results.stdout; //plausible value = arn:aws:iam::111122223333:user/example
+            }
+        }
+        return CDK_Deployer.iam_id; //returns IAM of user/role running `cdk deploy dev1-eks`
+    }
+} //end CDK_Deployer
 
 
 
@@ -227,13 +244,7 @@ export class Easy_EKS{ //purposefully don't extend stack, to implement builder p
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        //Logic to create cluster:
-        //UX convienence similar to EKS Blueprints
-        const assumableEKSAdminAccessRole = new iam.Role(this.stack, 'assumableEKSAdminAccessRole', {
-          assumedBy: new iam.AccountRootPrincipal(), //<-- root as is root of the account,
-                                                     // so assumable by any principle/identity in the account.
-        });
-  
+        // Logic to create cluster:  
         // if (kms.Key.isLookupDummy(kms.Key.fromLookup(this.stack, "pre-existing-kms-key", { aliasName: this.config.kmsKeyAlias, returnDummyKeyOnMissing: true,  }))){
         //     eksBlueprint.resourceProvider(blueprints.GlobalResources.KmsKey, new blueprints.CreateKmsKeyProvider(
         //     this.config.kmsKeyAlias, {description: "Easy EKS generated kms key, used to encrypt etcd and ebs-csi-driver provisioned volumes"}
@@ -251,9 +262,16 @@ export class Easy_EKS{ //purposefully don't extend stack, to implement builder p
             defaultCapacity: 0,
             tags: this.config.tags,
             authenticationMode: eks.AuthenticationMode.API_AND_CONFIG_MAP,
-            mastersRole: assumableEKSAdminAccessRole, //<-- adds aws eks update-kubeconfig output
+            // mastersRole: //<-- This is the built in way to set output associated with update-kubeconfig
+            // The role specified is usually assumable by iam.AccountRootPrinciple which isn't secure
+            // so mastersRole is purposefully commented out / not implemented for improved security.
             secretsEncryptionKey: kms_key,
         });
+        //v-- This achieve similar yet better results than commented out mastersRole
+        const msg = `aws eks update-kubeconfig --region ${this.stack.region} --name ${this.config.id}\n\n` +
+        'Note: This only works for the user/role deploying cdk and IAM Whitelisted Admins.\n'+
+        '      To learn more review ./easyeks/config/eks/lower_envs_eks_config.ts';
+        const output_msg = new cdk.CfnOutput(this.stack, 'iamWhitelistedKubeConfigCmd', { value: msg });
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -314,6 +332,13 @@ export class Easy_EKS{ //purposefully don't extend stack, to implement builder p
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Logic to add the person running cdk deploy to the list of cluster admins
+        // This satisfies EKS IAM access entry rights prerequisite, needed to allow the output command to work
+        // aws eks update-kubeconfig --region ca-central-1 --name dev1-eks
+        this.config.addClusterAdminARN(CDK_Deployer.get_IAM_ID());
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Logic to add Cluster Admins Defined in Config as Code:
         const clusterAdminAccessPolicy: eks.AccessPolicy = eks.AccessPolicy.fromAccessPolicyName('AmazonEKSClusterAdminPolicy', {
           accessScopeType: eks.AccessScopeType.CLUSTER
@@ -368,7 +393,10 @@ function initialize_WorkerNodeRole(stack: cdk.Stack){
       },
   });
   EKS_Worker_Node_Role.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN); //Workaround to avoid cdk destroy bug
-  return EKS_Worker_Node_Role
+  // ^--This leaves orphaned IAM roles, which isn't ideal, yet least bad option.
+  //    Shouldn't hurt anything in most cases (there is a max of 1000 IAM roles per AWS account)
+  //    It'd only be a problem after 100's of deploy & destroy operations, after which it's easy to manually clean up.
+  return EKS_Worker_Node_Role;
 }
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/lib/Easy_EKS_Config_Data.ts
+++ b/lib/Easy_EKS_Config_Data.ts
@@ -4,7 +4,7 @@ import * as eks from 'aws-cdk-lib/aws-eks';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as kms from 'aws-cdk-lib/aws-kms';
-import { execSync } from 'child_process';
+import * as shell from 'shelljs'; //npm install shelljs && npm i --save-dev @types/shelljs
 import { validateTag } from './Utilities';
 
 export class Easy_EKS_Config_Data { //This object just holds config data.
@@ -59,7 +59,7 @@ export class Easy_EKS_Config_Data { //This object just holds config data.
         // knowledge of how to handle the edge case.
         ////////////////////////////////////////////////////////////////////////////////
         const cmd = `aws ec2 describe-vpcs --filter Name=tag:Name,Values=${vpcName} --query "Vpcs[].VpcId" | tr -d '\r\n []"'`
-        const cmd_results = execSync(cmd).toString();
+        const cmd_results = shell.exec(cmd, {silent:true}).stdout;
         // Plausible Values to expect:
         // case 1: cmd_results===""
         //         ^-- Occurs when vpc name not found. Would cause an error, which is desired behavior as we assume it should be found.

--- a/lib/Easy_EKS_Config_Data.ts
+++ b/lib/Easy_EKS_Config_Data.ts
@@ -86,7 +86,7 @@ export class Easy_EKS_Config_Data { //This object just holds config data.
         try {
             validateTag(key, value)
             if(this.tags === undefined){ this.tags = { [key] : value } }
-            else{ this.tags = { ...this.tags, [key] : value }}
+            else{ this.tags = { ...this.tags, [key] : value } }
         } catch (error: any) {
             console.error("Error:", error.message)
             throw "Error validating tags. See details above"// Using throw here to stop the checks; otherwise an error will print out for every place this tag would be applied, and the process will continue
@@ -100,12 +100,20 @@ export class Easy_EKS_Config_Data { //This object just holds config data.
     }
     setIpMode(ipMode: eks.IpFamily){ this.ipMode = ipMode; }
     addClusterAdminARN(arn:string){        //v--initialize if undefined
-        if(this.clusterAdminAccessEksApiArns === undefined){ this.clusterAdminAccessEksApiArns = [arn] } 
-        else{ this.clusterAdminAccessEksApiArns.push(arn); } //push means add to end of array
+        if(this.clusterAdminAccessEksApiArns === undefined){ this.clusterAdminAccessEksApiArns = [arn]; }
+        else{
+            if(!this.clusterAdminAccessEksApiArns.includes(arn)){ //if value isn't already in array
+                this.clusterAdminAccessEksApiArns.push(arn); //then push, as in add, to end of array
+            }
+        } 
     }
     addClusterViewerAccount(account:string){        //v--initialize if undefined
         if(this.clusterViewerAccessAwsAuthConfigmapAccounts === undefined){ this.clusterViewerAccessAwsAuthConfigmapAccounts = [account] } 
-        else{ this.clusterViewerAccessAwsAuthConfigmapAccounts.push(account); } //push means add to end of array
+        else{
+            if(!this.clusterViewerAccessAwsAuthConfigmapAccounts.includes(account)){ //if value isn't already in array
+            this.clusterViewerAccessAwsAuthConfigmapAccounts.push(account); //then push, as in add, to end of array
+            }
+        } 
     }
     setKmsKeyAlias(kms_key_alias: string){
         /*Note (About UX improvement logic):

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cdk-eks-karpenter": "^1.0.16",
         "cdk-fck-nat": "^1.5.6",
         "constructs": "^10.0.0",
+        "shelljs": "^0.10.0",
         "sync-request-curl": "^3.1.0"
       },
       "bin": {
@@ -21,6 +22,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "^22.7.9",
+        "@types/shelljs": "^0.8.16",
         "aws-cdk": "^2.1004.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
@@ -1142,6 +1144,41 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@npmcli/agent": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
@@ -1308,6 +1345,17 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1356,6 +1404,13 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.15.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
@@ -1364,6 +1419,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/shelljs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.16.tgz",
+      "integrity": "sha512-40SUXiH0tZfAg/oKkkGF1kdHPAmE4slv2xAmbfa8VtE6ztHYwdpW2phlzHTVdJh5JOGqA3Cx1Hzp7kxFalKHYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob": "~7.2.0",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -2047,7 +2113,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2695,7 +2760,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -2747,12 +2811,37 @@
       "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
       "license": "Apache-2.0"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -2801,7 +2890,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2968,7 +3056,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2996,6 +3083,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/globals": {
@@ -3095,7 +3194,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -3211,6 +3309,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3230,6 +3337,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
@@ -3240,7 +3359,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -3250,7 +3368,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4160,14 +4277,21 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -4181,7 +4305,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4757,7 +4880,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -4801,7 +4923,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -4976,7 +5097,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5089,6 +5209,26 @@
       ],
       "license": "MIT"
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -5180,6 +5320,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -5194,6 +5344,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -5260,6 +5433,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
+      "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "fast-glob": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/signal-exit": {
@@ -5474,7 +5660,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5577,7 +5762,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -13,18 +13,20 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "^22.7.9",
+    "@types/shelljs": "^0.8.16",
+    "aws-cdk": "^2.1004.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
-    "aws-cdk": "^2.1004.0",
     "ts-node": "^10.9.2",
     "typescript": "~5.8.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.193.0",
-    "constructs": "^10.0.0",
     "@aws-cdk/lambda-layer-kubectl-v31": "^2.0.3",
+    "aws-cdk-lib": "2.193.0",
     "cdk-eks-karpenter": "^1.0.16",
     "cdk-fck-nat": "^1.5.6",
+    "constructs": "^10.0.0",
+    "shelljs": "^0.10.0",
     "sync-request-curl": "^3.1.0"
   }
 }


### PR DESCRIPTION
**Summary of Changes:** 
1. **Replaced execSync with shelljs**
    * supposed to be trivially more secure
    * noteworthy improvement is before only stdout of commands was accessible. Now stderr & exit codes are also accessible/usable, which can make any if statement logic more reliable.
2. **Security Improvement:**
    * **Removed:** AWS Account root (as in any authenticated user/role within account) assumable eks cluster admin method (insecure default built into cdk's eks masterrole logic) has been removed.  
      Here's what the output used to look like:
      ```console
      Outputs:
      dev1-eks.dev1eksConfigCommand9B300592 = aws eks update-kubeconfig --name dev1-eks --region ca-central-1 --role-arn arn:aws:iam::905418347382:role/dev1-eks-assumableEKSAdminAccessRoleC284FA0F-F22KjKQrjLpO
      ```
     * **Replaced with:** Only allowing cluster admin access to IAM ARN List of Whitelisted Cluster Admins (and convenience logic to add the user/role running `cdk deploy dev1-eks` to said list to maintain similar UX to what originally existed.)  
       Here's what the output now looks like:  (quickstart doc was updated to reflect)
       ```console
       Outputs:
       dev1-eks.iamWhitelistedKubeConfigCmd = aws eks update-kubeconfig --region ca-central-1 --name dev1-eks
       ```
3. **Edge Case Bug Fix:**
    * Duplicate Entries of `config.addClusterAdminARN(`arn:aws:iam::111122223333:user/example`);`
       would cause crash. Logic to prevent duplicates has been added.
    * Duplicate Entires of `config.addClusterViewerAccount(process.env.CDK_DEFAULT_ACCOUNT!);`
       would not cause any crash, nor issues, but it would result in duplicate entries in aws-auth configmap. Added logic to prevent duplicates here as well even though didn't hurt.
    * Verified tag duplicates were non-issue.